### PR TITLE
Provide gen and arbitrary instances for catId and cat

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,23 +1,24 @@
-{-# LANGUAGE DeriveGeneric #-}
 module Lib where
 
-import Data.List.NonEmpty ( NonEmpty )
-import GHC.Generics ( Generic )
+import Data.List.NonEmpty (NonEmpty)
 
+newtype CategoryId = CategoryId Int deriving (Eq, Show)
 
-newtype CategoryId = CategoryId Int deriving (Eq, Show, Generic)
+data Category = Category
+  { categoryId :: CategoryId,
+    active :: Bool,
+    selectable :: Bool,
+    language :: String,
+    left :: Int,
+    right :: Int,
+    text :: String
+  }
+  deriving (Eq, Show)
 
-data Category = Category {
-  categoryId :: CategoryId,
-  active :: Bool,
-  selectable :: Bool,
-  language :: String,
-  left :: Int,
-  right :: Int,
-  text :: String
-} deriving (Eq, Show, Generic)
 type CategoryTree = [Category]
 
+--data Error = CategoryNotFound | TreeDescriptionCorrupted deriving (Eq, Show)
+--breadcrumb :: CategoryTree -> CategoryId -> Either Error (NonEmpty CategoryId)
 breadcrumb :: CategoryTree -> CategoryId -> Maybe (NonEmpty CategoryId)
 breadcrumb _ _ = Nothing
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/9.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/4.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -1,26 +1,41 @@
 module LibSpec where
 
-import Data.Maybe ( isNothing )
--- import Test.QuickCheck.Arbitrary ( Arbitrary )
-import Test.Hspec ( describe, it, shouldBe, Spec )
-import Test.Hspec.QuickCheck ( prop )
-import Test.QuickCheck.Property ( (==>) )
-import Lib ( breadcrumb, Category(categoryId), CategoryId, CategoryTree )
+import Data.Maybe (isNothing)
+import Lib
+import Test.Hspec (Spec, describe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (Gen, listOf)
+import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
+import Test.QuickCheck.Property (forAll)
 
--- instance Arbitrary CategoryId
--- instance Arbitrary Category
+genCategoryId :: Gen CategoryId
+genCategoryId = CategoryId <$> arbitrary
+
+instance Arbitrary CategoryId where
+  arbitrary = genCategoryId
+
+-- this is a silly generator, we want to generate something better next time + avoid orphan instances
+instance Arbitrary Category where
+  arbitrary = sillyGenCategory
+
+sillyGenCategory :: Gen Category
+sillyGenCategory = Category <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 spec :: Spec
 spec = describe "breadcrumb" $ do
+  prop "returns Nothing iff categoryId is not present in the tree (manual monadic generators)" $
+    forAll genCategoryId $ \c ->
+      forAll (listOf sillyGenCategory) $ \t ->
+        let isCategoryPresent t cid = cid `elem` fmap categoryId t
+         in isNothing (breadcrumb t c) == not (isCategoryPresent t c)
 
-   prop "returns Nothing iff categoryId is not present in the tree" $
-     \t c -> isNothing (breadcrumb t c) == not (isCategoryPresent t c)
+  prop "returns Nothing iff categoryId is not present in the tree (automatic type class resolution)" $
+    \c t ->
+      let isCategoryPresent t c = c `elem` fmap categoryId t
+       in isNothing (breadcrumb t c) == not (isCategoryPresent t c)
 
-   -- prop "must return Nothing if categoryId is not present in the tree" $
-   --   \t c -> not (isCategoryPresent t c) ==> isNothing (breadcrumb t c)
+-- prop "must return Nothing if categoryId is not present in the tree" $
+--   \t c -> not (isCategoryPresent t c) ==> isNothing (breadcrumb t c)
 
-   -- prop "must return Nothing ONLY if categoryId is not present in the tree" $
-   --   \t c -> isNothing (breadcrumb t c) ==> not (isCategoryPresent t c)
-
-isCategoryPresent :: CategoryTree -> CategoryId -> Bool
-isCategoryPresent t cid = cid `elem` fmap categoryId t
+-- prop "must return Nothing ONLY if categoryId is not present in the tree" $
+--   \t c -> isNothing (breadcrumb t c) ==> not (isCategoryPresent t c)


### PR DESCRIPTION
In scope
* manual generator for categoryid. Could be generated using GeneratedVia, since we don't leverage anything specific about the model (Categoryid is isomorphic to Int and is used just to increase type safety / avoid boolean blindness) 
* manual (silly) generator for category: this is were we should do better and generate "consistent" data (except maybe for a test to check how resilient our business logic is to corrupted data). Will improve next time
* corresponding Arbitrary (orphan) instances. It's bad practise to allow orphan instances, and in general it's better to manually plug the generators, however in small projects it's helpful to use/abuse type class resolution 
* example of the same test plugging generators manually or via type class resolution 