### PR TITLE
Aeson custom deserialiser

### DIFF
--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -4,12 +4,21 @@ import Data.Maybe (isNothing)
 import Lib
 import Test.Hspec (Spec, describe)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Gen, listOf)
+import Test.QuickCheck (Gen, elements, listOf)
 import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 import Test.QuickCheck.Property (forAll)
 
 genCategoryId :: Gen CategoryId
 genCategoryId = CategoryId <$> arbitrary
+
+instance Arbitrary CategoryState where
+  arbitrary = elements [Active, Inactive]
+
+instance Arbitrary CategorySelectableState where
+  arbitrary = elements [Selectable, Unselectable]
+
+instance Arbitrary CategoryDescription where
+  arbitrary = CategoryDescription <$> arbitrary
 
 instance Arbitrary CategoryId where
   arbitrary = genCategoryId


### PR DESCRIPTION
To avoid using unusual, mixed case naming conventions for records in haskell code, I'm suggesting here to remove the automatic generation of aeson parsers using Generics (which is probably still overkilling for this particular example) and rely instead on a trivial manual parsing for the `category` type. the final parser can be expressed by combining in an applicative fashion simpler parsers. 

in addition, to avoid boolean blindness, i've created different types to represent the status of a category

I've removed the `(run)` in 
```
module Lib (run) where
```
intentionally. For testing, but also because i rarely value the fact of having private methods, unless the module is really part of an SDK that would be distributed. 

Notice: I'm targetting @horothesun 's `fetchCategoryTree` branch related to https://github.com/haskell-fun/CategoryBreadcrumb/pull/2 and not merged to main yet. 